### PR TITLE
read from input

### DIFF
--- a/src/pyironFileReader/__init__.py
+++ b/src/pyironFileReader/__init__.py
@@ -61,7 +61,7 @@ class PyironFileReader(FileReaderInterface):
             # Particle type
             typeProperty = particles.create_property("Particle Type")
             typeList = eval(
-                "".join([chr(item) for item in f[key]["output/structure/species"][:]])
+                "".join([chr(item) for item in f[key]["input/structure/species"][:]])
             )
             uTypesH5 = np.unique(f[key]["output/generic/indices"][localIdx])
             uTypesOvito = np.zeros(uTypesH5[-1] + 1, dtype=int)
@@ -104,7 +104,7 @@ class PyironFileReader(FileReaderInterface):
                     cellMatrix[idx] = (
                         0 if cellMatrix[idx] <= self.roundCellBy else cellMatrix[idx]
                     )
-            data.create_cell(cellMatrix, pbc=f[key]["output/structure/cell/pbc"][:])
+            data.create_cell(cellMatrix, pbc=f[key]["input/structure/cell/pbc"][:])
 
             # Attributes
             for h5Key, ovitoKey in self.attributes_dict.items():

--- a/src/pyironFileReader/__init__.py
+++ b/src/pyironFileReader/__init__.py
@@ -60,9 +60,18 @@ class PyironFileReader(FileReaderInterface):
             )
             # Particle type
             typeProperty = particles.create_property("Particle Type")
-            typeList = eval(
-                "".join([chr(item) for item in f[key]["input/structure/species"][:]])
-            )
+            try:
+                typeList = eval(
+                    "".join(
+                        [chr(item) for item in f[key]["output/structure/species"][:]]
+                    )
+                )
+            except KeyError:
+                typeList = eval(
+                    "".join(
+                        [chr(item) for item in f[key]["input/structure/species"][:]]
+                    )
+                )
             uTypesH5 = np.unique(f[key]["output/generic/indices"][localIdx])
             uTypesOvito = np.zeros(uTypesH5[-1] + 1, dtype=int)
             for u in uTypesH5:
@@ -104,7 +113,10 @@ class PyironFileReader(FileReaderInterface):
                     cellMatrix[idx] = (
                         0 if cellMatrix[idx] <= self.roundCellBy else cellMatrix[idx]
                     )
-            data.create_cell(cellMatrix, pbc=f[key]["input/structure/cell/pbc"][:])
+            try:
+                data.create_cell(cellMatrix, pbc=f[key]["output/structure/cell/pbc"][:])
+            except KeyError:
+                data.create_cell(cellMatrix, pbc=f[key]["input/structure/cell/pbc"][:])
 
             # Attributes
             for h5Key, ovitoKey in self.attributes_dict.items():


### PR DESCRIPTION
Apparently there are some changes to the h5 lammps format in pyiron. By reading from input instead of out the file reader can read my old and my new simulations.